### PR TITLE
Install bash completion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN true \
 # packages for awt:
     && apt-get install libxext6 libxrender1 libxtst6 libxi6 libfreetype6 -y \
 # packages for user convenience:
-    && apt-get install git -y \
+    && apt-get install git bash-completion -y \
 # packages for IDEA (to disable warnings):
     && apt-get install procps -y \
 # clean apt to reduce image size:


### PR DESCRIPTION
I very like to use the Terminal in projector. But the autocomplete package is missing. I can fully understand when you decline this pr. That packge is 202kb and would not change the size too much :)

https://packages.debian.org/buster/bash-completion

PS: Thanks for building such nice Software! ❤️ 