### PR TITLE
[Android Studio support] Add game-tools to ignore

### DIFF
--- a/static/ide-projector-launcher.sh
+++ b/static/ide-projector-launcher.sh
@@ -28,6 +28,8 @@ for i in "${!ideRunnerCandidates[@]}"; do
         unset 'ideRunnerCandidates[i]'
     elif [[ ${ideRunnerCandidates[i]} = *"projector"* ]]; then
         unset 'ideRunnerCandidates[i]'
+    elif [[ ${ideRunnerCandidates[i]} = *"game-tools.sh" ]]; then
+        unset 'ideRunnerCandidates[i]'
     fi
 done
 


### PR DESCRIPTION
# Background

Now we can start android studio, but when we start it we get the error that there are too many runtime files. The solution to this problem is to ignore the `game-tools.sh` file and run only `studio.sh`
After this fix, we can start android studio simply by substituting the desired link. 
Everything works for me with this link: `https://redirector.gvt1.com/edgedl/android/studio/ide-zips/4.2.0.22/android-studio-ide-202.7188722-linux.tar.gz`

# Changes
- Add `elif` branch for ignore in runnerCandidates

# Test plan
- Replace `downloadUrl` to `https://redirector.gvt1.com/edgedl/android/studio/ide-zips/4.2.0.22/android-studio-ide-202.7188722-linux.tar.gz`
- Run `./clone-projector-core.sh`
- Run `./build-container.sh`
- Run `./run-container.sh`
- Check that all work correctly (open in browser `localhost:8887`)