### PR TITLE
support mps startup script

### DIFF
--- a/static/ide-projector-launcher.sh
+++ b/static/ide-projector-launcher.sh
@@ -59,10 +59,9 @@ sed -i 's+com.intellij.idea.Main+-Dorg.jetbrains.projector.server.classToLaunch=
 # change
 # ${MAIN_CLASS}
 # to
-# -Dorg.jetbrains.projector.server.classToLaunch=jetbrains.mps.Launcher ${MAIN_CLASS}
+# -Dorg.jetbrains.projector.server.classToLaunch=${MAIN_CLASS} org.jetbrains.projector.server.ProjectorLauncher
 sed -i 's+\${MAIN_CLASS}+-Dorg.jetbrains.projector.server.classToLaunch=\${MAIN_CLASS} org.jetbrains.projector.server.ProjectorLauncher+g' "$IDE_RUN_FILE_NAME-projector.sh"
 
 bash "$IDE_RUN_FILE_NAME-projector.sh"
 
 rm "$IDE_RUN_FILE_NAME-projector.sh"
-

--- a/static/ide-projector-launcher.sh
+++ b/static/ide-projector-launcher.sh
@@ -20,7 +20,7 @@
 
 THIS_FILE_NAME=$(basename "$0")
 
-ideRunnerCandidates=($(grep -lr --include=*.sh com.intellij.idea.Main .))
+ideRunnerCandidates=($(grep -lr --include=*.sh "com.intellij.idea.Main\|jetbrains.mps.Launcher" .))
 
 # remove this file from candidates:
 for i in "${!ideRunnerCandidates[@]}"; do
@@ -55,6 +55,12 @@ sed -i 's+classpath "$CLASSPATH"+classpath "$CLASSPATH:$IDE_HOME/projector-serve
 # to
 # -Dorg.jetbrains.projector.server.classToLaunch=com.intellij.idea.Main org.jetbrains.projector.server.ProjectorLauncher
 sed -i 's+com.intellij.idea.Main+-Dorg.jetbrains.projector.server.classToLaunch=com.intellij.idea.Main org.jetbrains.projector.server.ProjectorLauncher+g' "$IDE_RUN_FILE_NAME-projector.sh"
+
+# change
+# ${MAIN_CLASS}
+# to
+# -Dorg.jetbrains.projector.server.classToLaunch=jetbrains.mps.Launcher ${MAIN_CLASS}
+sed -i 's+\${MAIN_CLASS}+-Dorg.jetbrains.projector.server.classToLaunch=\${MAIN_CLASS} org.jetbrains.projector.server.ProjectorLauncher+g' "$IDE_RUN_FILE_NAME-projector.sh"
 
 bash "$IDE_RUN_FILE_NAME-projector.sh"
 


### PR DESCRIPTION
Even though listed in the [compatible_ides.json](https://github.com/JetBrains/projector-installer/blob/master/projector_installer/compatible_ide.json), MPS doesn't launch without modifications. This PR changes that.

# Steps to Reproduce

1. check out this repository
2. `./clone-projector-core.sh`
3. `./build-container.sh mps-20.3 https://download.jetbrains.com/mps/2020.3/MPS-2020.3.3.tar.gz`
4. `./run-container.sh mps-20.3`

# Before
In the past, the above ended with this:

```
+ cd /projector/ide/bin
+ ./ide-projector-launcher.sh
Can't find a single candidate to be IDE runner script so can't select a single one:
```

# After
But now, it properly launches MPS
```
+ cd /projector/ide/bin
+ ./ide-projector-launcher.sh
Found IDE: mps
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
[DEBUG] :: IdeState :: Starting attempts to attach IJ injector agent
[DEBUG] :: IdeState :: Starting attempts to initialize IDEA: fix AA and disable smooth scrolling (at start)
[INFO] :: ProjectorServer :: ProjectorServer is starting on host 0.0.0.0/0.0.0.0 and port 8887
[DEBUG] :: IdeState :: Starting attempts to Getting IDE colors
[INFO] :: ProjectorServer :: WebSocket SSL is disabled
[INFO] :: ProjectorServer :: Server started on host 0.0.0.0/0.0.0.0 and port 8887
...
```