### PR TITLE
Add missing expose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,4 +115,6 @@ RUN true \
 USER $PROJECTOR_USER_NAME
 ENV HOME /home/$PROJECTOR_USER_NAME
 
+EXPOSE 8887
+
 CMD ["bash", "-c", "/run.sh"]


### PR DESCRIPTION
I am switching from nginx-proxy to traefik. But this image misses an expose port, so traefik complains by default :)

Apr 10 19:49:47 eevee traefik[8288]: time="2021-04-10T19:49:47+02:00" level=error msg="service \"phpstorm-dev\" error: port is missing" providerName=docker container=phpstorm-dev

Thanks for building this ❤️ 